### PR TITLE
fixed Flask version so it works with jinja2

### DIFF
--- a/server/requirements.txt
+++ b/server/requirements.txt
@@ -1,2 +1,2 @@
-Flask==1.1.2
+Flask==2.1.0
 Flask-Cors==3.0.10


### PR DESCRIPTION
The current version does not work. `python app.py` results in  `ImportError: cannot import name 'escape' from 'jinja2'`.

Fixed that, with https://stackoverflow.com/questions/71718167/importerror-cannot-import-name-escape-from-jinja2